### PR TITLE
Adjust tap area of dark mode toggle

### DIFF
--- a/src/app/components/theme-toggle.tsx
+++ b/src/app/components/theme-toggle.tsx
@@ -24,7 +24,7 @@ const ThemeToggle = () => {
   return (
     <button
       onClick={() => (currentTheme == "dark" ? setTheme("light") : setTheme("dark"))}
-      className="px-4 py-2 lg:px-8 lg:py-2"
+      className="w-fit px-4 py-2 lg:px-8 lg:py-2"
     >
       <Image
         src={


### PR DESCRIPTION
It was wayyy to big. Seems like somehow the default behavior of a button within a grid layout is to assume that all of the available space in the layout is its tap target??